### PR TITLE
Added methods to the SchemaChecker to check for undefined attributes …

### DIFF
--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaCheckFilterVisitor.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaCheckFilterVisitor.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2017 UnboundID Corp.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+package com.unboundid.scim2.server.utils;
+
+import com.unboundid.scim2.common.Path;
+import com.unboundid.scim2.common.exceptions.ScimException;
+import com.unboundid.scim2.common.filters.AndFilter;
+import com.unboundid.scim2.common.filters.ComparisonFilter;
+import com.unboundid.scim2.common.filters.ComplexValueFilter;
+import com.unboundid.scim2.common.filters.ContainsFilter;
+import com.unboundid.scim2.common.filters.EndsWithFilter;
+import com.unboundid.scim2.common.filters.EqualFilter;
+import com.unboundid.scim2.common.filters.Filter;
+import com.unboundid.scim2.common.filters.FilterVisitor;
+import com.unboundid.scim2.common.filters.GreaterThanFilter;
+import com.unboundid.scim2.common.filters.GreaterThanOrEqualFilter;
+import com.unboundid.scim2.common.filters.LessThanFilter;
+import com.unboundid.scim2.common.filters.LessThanOrEqualFilter;
+import com.unboundid.scim2.common.filters.NotEqualFilter;
+import com.unboundid.scim2.common.filters.NotFilter;
+import com.unboundid.scim2.common.filters.OrFilter;
+import com.unboundid.scim2.common.filters.PresentFilter;
+import com.unboundid.scim2.common.filters.StartsWithFilter;
+import com.unboundid.scim2.common.types.AttributeDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static com.unboundid.scim2.server.utils.SchemaChecker.Option.ALLOW_UNDEFINED_ATTRIBUTES;
+import static com.unboundid.scim2.server.utils.SchemaChecker.Option.ALLOW_UNDEFINED_SUB_ATTRIBUTES;
+
+
+
+/**
+ * Filter visitor to check attribute paths against the schema.
+ */
+public final class SchemaCheckFilterVisitor
+    implements FilterVisitor<Filter, Object>
+{
+  private final Path parentPath;
+  private final ResourceTypeDefinition resourceType;
+  private final SchemaChecker schemaChecker;
+  private final SchemaChecker.Results results;
+
+
+  private SchemaCheckFilterVisitor(
+      final Path parentPath,
+      final ResourceTypeDefinition resourceType,
+      final SchemaChecker schemaChecker,
+      final SchemaChecker.Results results)
+  {
+    this.parentPath = parentPath;
+    this.resourceType = resourceType;
+    this.schemaChecker = schemaChecker;
+    this.results = results;
+  }
+
+
+
+  /**
+   * Check the provided filter against the schema.
+   *
+   * @param filter   The filter to check.
+   * @param resourceTypeDefinition The schema to check the filter against.
+   * @param enabledOptions  The schema checker enabled options.
+   * @param results  The results of checking the filter.
+   * @throws ScimException If an exception occurs during the operation.
+   */
+  static void checkFilter(
+      final Filter filter,
+      final ResourceTypeDefinition resourceTypeDefinition,
+      final SchemaChecker schemaChecker,
+      final Set<SchemaChecker.Option> enabledOptions,
+      final SchemaChecker.Results results)
+      throws ScimException
+  {
+    if (enabledOptions.contains(ALLOW_UNDEFINED_ATTRIBUTES) &&
+        enabledOptions.contains(ALLOW_UNDEFINED_SUB_ATTRIBUTES))
+    {
+      // Nothing to check because all undefined attributes are allowed.
+      return;
+    }
+
+    final SchemaCheckFilterVisitor visitor =
+        new SchemaCheckFilterVisitor(
+            null, resourceTypeDefinition, schemaChecker, results);
+    filter.visit(visitor, null);
+  }
+
+
+
+  /**
+   * Check the provided value filter in a patch path against the schema.
+   *
+   * @param parentPath  The parent attribute associated with the value filter.
+   * @param filter   The value filter to check.
+   * @param resourceTypeDefinition The schema to check the filter against.
+   * @param enabledOptions  The schema checker enabled options.
+   * @param results  The results of checking the filter.
+   * @throws ScimException If an exception occurs during the operation.
+   */
+  static void checkValueFilter(
+      final Path parentPath,
+      final Filter filter,
+      final ResourceTypeDefinition resourceTypeDefinition,
+      final SchemaChecker schemaChecker,
+      final Set<SchemaChecker.Option> enabledOptions,
+      final SchemaChecker.Results results)
+      throws ScimException
+  {
+    if (enabledOptions.contains(ALLOW_UNDEFINED_SUB_ATTRIBUTES))
+    {
+      // Nothing to check because all undefined sub-attributes are allowed.
+      return;
+    }
+
+    final SchemaCheckFilterVisitor visitor =
+        new SchemaCheckFilterVisitor(
+            parentPath, resourceTypeDefinition, schemaChecker, results);
+    filter.visit(visitor, null);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final EqualFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final NotEqualFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final ContainsFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final StartsWithFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final EndsWithFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final PresentFilter filter, final Object param)
+      throws ScimException
+  {
+    checkAttributePath(filter.getAttributePath());
+    return filter;
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final GreaterThanFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final GreaterThanOrEqualFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final LessThanFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final LessThanOrEqualFilter filter, final Object param)
+      throws ScimException
+  {
+    return visitComparisonFilter(filter, param);
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final AndFilter filter, final Object param)
+      throws ScimException
+  {
+    for (Filter f : filter.getCombinedFilters())
+    {
+      f.visit(this, param);
+    }
+    return filter;
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final OrFilter filter, final Object param)
+      throws ScimException
+  {
+    for (Filter f : filter.getCombinedFilters())
+    {
+      f.visit(this, param);
+    }
+    return filter;
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final NotFilter filter, final Object param)
+      throws ScimException
+  {
+    filter.getInvertedFilter().visit(this, param);
+    return filter;
+  }
+
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public Filter visit(final ComplexValueFilter filter, final Object param)
+      throws ScimException
+  {
+    checkAttributePath(filter.getAttributePath());
+    return filter;
+  }
+
+
+
+  private Filter visitComparisonFilter(final ComparisonFilter filter,
+                                       final Object param)
+  {
+    checkAttributePath(filter.getAttributePath());
+    return filter;
+  }
+
+
+
+  private void checkAttributePath(final Path path)
+  {
+    if (this.parentPath != null)
+    {
+      final Path fullPath = parentPath.attribute(path);
+      final AttributeDefinition attribute =
+          resourceType.getAttributeDefinition(fullPath);
+      if (attribute == null)
+      {
+        // Can't find the definition for the sub-attribute in a value filter.
+        results.addFilterIssue(
+            "Sub-attribute " + path.getElement(0) +
+            " in value filter for path " + parentPath.toString() +
+            " is undefined");
+      }
+    }
+    else
+    {
+      final AttributeDefinition attribute =
+          resourceType.getAttributeDefinition(path);
+      if (attribute == null)
+      {
+        // Can't find the attribute definition for attribute in path.
+        final List<String> messages = new ArrayList<String>();
+        schemaChecker.addMessageForUndefinedAttr(path, "", messages);
+        if (!messages.isEmpty())
+        {
+          for (String m : messages)
+          {
+            results.addFilterIssue(m);
+          }
+        }
+      }
+    }
+  }
+}

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
@@ -1061,6 +1061,12 @@ public class SchemaCheckerTestCase
     assertTrue(containsIssueWith(results.getPathIssues(),
         "is undefined"));
 
+    results = checker.checkSearch(Filter.fromString("undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
+        "is undefined"));
+
     // Core sub-attribute is undefined
     ObjectNode coreSubUndefined = JsonUtils.getJsonNodeFactory().objectNode();
     coreSubUndefined.putArray("schemas").
@@ -1098,6 +1104,12 @@ public class SchemaCheckerTestCase
     assertEquals(results.getPathIssues().size(), 1,
         results.getPathIssues().toString());
     assertTrue(containsIssueWith(results.getPathIssues(),
+        "is undefined"));
+
+    results = checker.checkSearch(Filter.fromString("name.undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
         "is undefined"));
 
     // Extended attribute is undefined
@@ -1143,6 +1155,13 @@ public class SchemaCheckerTestCase
     assertEquals(results.getPathIssues().size(), 1,
         results.getPathIssues().toString());
     assertTrue(containsIssueWith(results.getPathIssues(),
+        "is undefined"));
+
+    results = checker.checkSearch(Filter.fromString(
+        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
         "is undefined"));
 
     // Extended sub-attribute is undefined
@@ -1192,6 +1211,13 @@ public class SchemaCheckerTestCase
     assertEquals(results.getPathIssues().size(), 1,
         results.getPathIssues().toString());
     assertTrue(containsIssueWith(results.getPathIssues(),
+        "is undefined"));
+
+    results = checker.checkSearch(Filter.fromString(
+        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
         "is undefined"));
   }
 
@@ -1282,6 +1308,18 @@ public class SchemaCheckerTestCase
     assertTrue(containsIssueWith(results.getPathIssues(),
         "is undefined"));
 
+    results = undefinedAttributesChecker.checkSearch(
+        Filter.fromString("undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 0,
+        results.getFilterIssues().toString());
+
+    results = undefinedSubAttributesChecker.checkSearch(
+        Filter.fromString("undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
+        "is undefined"));
+
     // Core sub-attribute is undefined
     ObjectNode coreSubUndefined = JsonUtils.getJsonNodeFactory().objectNode();
     coreSubUndefined.putArray("schemas").
@@ -1343,6 +1381,18 @@ public class SchemaCheckerTestCase
             Path.root().attribute("name").attribute("undefined"))), null);
     assertEquals(results.getPathIssues().size(), 0,
         results.getPathIssues().toString());
+
+    results = undefinedAttributesChecker.checkSearch(
+        Filter.fromString("name.undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
+        "is undefined"));
+
+    results = undefinedSubAttributesChecker.checkSearch(
+        Filter.fromString("name.undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 0,
+        results.getFilterIssues().toString());
 
     // Extended attribute namespace is undefined
     ObjectNode extendedUndefined = JsonUtils.getJsonNodeFactory().objectNode();
@@ -1418,6 +1468,18 @@ public class SchemaCheckerTestCase
     assertTrue(containsIssueWith(results.getPathIssues(),
         "is undefined"));
 
+    results = undefinedAttributesChecker.checkSearch(
+        Filter.fromString("urn:undefined:undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 0,
+        results.getFilterIssues().toString());
+
+    results = undefinedSubAttributesChecker.checkSearch(
+        Filter.fromString("urn:undefined:undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
+        "is undefined"));
+
     // Extended attribute is undefined
     extendedUndefined = JsonUtils.getJsonNodeFactory().objectNode();
     extendedUndefined.putArray("schemas").
@@ -1488,6 +1550,18 @@ public class SchemaCheckerTestCase
     assertEquals(results.getPathIssues().size(), 1,
         results.getPathIssues().toString());
     assertTrue(containsIssueWith(results.getPathIssues(),
+        "is undefined"));
+
+    results = undefinedAttributesChecker.checkSearch(Filter.fromString(
+        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 0,
+        results.getFilterIssues().toString());
+
+    results = undefinedSubAttributesChecker.checkSearch(Filter.fromString(
+        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
         "is undefined"));
 
     // Extended sub-attribute is undefined
@@ -1565,6 +1639,20 @@ public class SchemaCheckerTestCase
             attribute("manager").attribute("undefined"))), null);
     assertEquals(results.getPathIssues().size(), 0,
         results.getPathIssues().toString());
+
+    results = undefinedAttributesChecker.checkSearch(
+        Filter.fromString(
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 1,
+        results.getFilterIssues().toString());
+    assertTrue(containsIssueWith(results.getFilterIssues(),
+        "is undefined"));
+
+    results = undefinedSubAttributesChecker.checkSearch(
+        Filter.fromString(
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.undefined eq \"value\""));
+    assertEquals(results.getFilterIssues().size(), 0,
+        results.getFilterIssues().toString());
   }
 
   /**


### PR DESCRIPTION
…and sub-attributes in a search filter, and in a value filter of a patch path, subject to the validation options set on the schema checker. See CR-5302 for more details.